### PR TITLE
now only update memory of true src and dst, support >1 neg sampling a…

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -25,13 +25,13 @@ class EdgePredictor(torch.nn.Module):
         self.dst_fc = torch.nn.Linear(dim_in, dim_in)
         self.out_fc = torch.nn.Linear(dim_in, 1)
 
-    def forward(self, h):
-        num_edge = h.shape[0] // 3
+    def forward(self, h, neg_samples=1):
+        num_edge = h.shape[0] // (neg_samples + 2)
         h_src = self.src_fc(h[:num_edge])
         h_pos_dst = self.dst_fc(h[num_edge:2 * num_edge])
         h_neg_dst = self.dst_fc(h[2 * num_edge:])
         h_pos_edge = torch.nn.functional.relu(h_src + h_pos_dst)
-        h_neg_edge = torch.nn.functional.relu(h_src + h_neg_dst)
+        h_neg_edge = torch.nn.functional.relu(h_src.tile(neg_samples, 1) + h_neg_dst)
         return self.out_fc(h_pos_edge), self.out_fc(h_neg_edge)
 
 

--- a/modules.py
+++ b/modules.py
@@ -45,7 +45,7 @@ class GeneralModel(torch.nn.Module):
         if 'combine' in gnn_param and gnn_param['combine'] == 'rnn':
             self.combiner = torch.nn.RNN(gnn_param['dim_out'], gnn_param['dim_out'])
     
-    def forward(self, mfgs):
+    def forward(self, mfgs, neg_samples=1):
         if self.memory_param['type'] == 'node':
             self.memory_updater(mfgs[0])
         out = list()
@@ -63,7 +63,7 @@ class GeneralModel(torch.nn.Module):
         else:
             out = torch.stack(out, dim=0)
             out = self.combiner(out)[0][-1, :, :]
-        return self.edge_predictor(out)
+        return self.edge_predictor(out, neg_samples=neg_samples)
 
     def get_emb(self, mfgs):
         if self.memory_param['type'] == 'node':


### PR DESCRIPTION
…t inference

*Issue #, if available:*

Description of changes: 
1. now node memory is only updated for source and positive destination node
2. add a feature to sample more than 1 negative node at inference


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
