### PR TITLE
Bug fix: compute updated supporting node memory

### DIFF
--- a/memorys.py
+++ b/memorys.py
@@ -51,7 +51,6 @@ class MailBox():
     def prep_input_mails(self, mfg, use_pinned_buffers=False):
         for i, b in enumerate(mfg):
             if use_pinned_buffers:
-                # idx = b.srcdata['ID'].cpu().long()
                 dst_idx = idx[:b.num_dst_nodes()]
                 torch.index_select(self.node_memory, 0, idx, out=self.pinned_node_memory_buffs[i][:idx.shape[0]])
                 b.srcdata['mem'] = self.pinned_node_memory_buffs[i][:idx.shape[0]].cuda(non_blocking=True)
@@ -62,7 +61,6 @@ class MailBox():
                 torch.index_select(self.mailbox_ts, 0, idx, out=self.pinned_mailbox_ts_buffs[i][:idx.shape[0]])
                 b.srcdata['mail_ts'] = self.pinned_mailbox_ts_buffs[i][:idx.shape[0]].cuda(non_blocking=True)
             else:
-                # dst_id = b.srcdata['ID'][:b.num_dst_nodes()].long()
                 b.srcdata['mem'] = self.node_memory[b.srcdata['ID'].long()].cuda()
                 b.srcdata['mem_ts'] = self.node_memory_ts[b.srcdata['ID'].long()].cuda()
                 b.srcdata['mem_input'] = self.mailbox[b.srcdata['ID'].long()].cuda().reshape(b.srcdata['ID'].shape[0], -1)

--- a/train.py
+++ b/train.py
@@ -110,7 +110,7 @@ def eval(mode='val'):
                 if memory_param['deliver_to'] == 'neighbors':
                     block = to_dgl_blocks(ret, sample_param['history'], reverse=True)[0][0]
                 mailbox.update_mailbox(model.memory_updater.last_updated_nid, model.memory_updater.last_updated_memory, root_nodes, ts, mem_edge_feats, block, neg_samples=neg_samples)
-                mailbox.update_memory(model.memory_updater.last_updated_nid, model.memory_updater.last_updated_memory, model.memory_updater.last_updated_ts, neg_samples=neg_samples)
+                mailbox.update_memory(model.memory_updater.last_updated_nid, model.memory_updater.last_updated_memory, root_nodes, model.memory_updater.last_updated_ts, neg_samples=neg_samples)
         if mode == 'val':
             val_losses.append(float(total_loss))
     ap = float(torch.tensor(aps).mean())
@@ -193,7 +193,7 @@ for e in range(train_param['epoch']):
             if memory_param['deliver_to'] == 'neighbors':
                 block = to_dgl_blocks(ret, sample_param['history'], reverse=True)[0][0]
             mailbox.update_mailbox(model.memory_updater.last_updated_nid, model.memory_updater.last_updated_memory, root_nodes, ts, mem_edge_feats, block)
-            mailbox.update_memory(model.memory_updater.last_updated_nid, model.memory_updater.last_updated_memory, model.memory_updater.last_updated_ts)
+            mailbox.update_memory(model.memory_updater.last_updated_nid, model.memory_updater.last_updated_memory, root_nodes, model.memory_updater.last_updated_ts)
         time_prep += time.time() - t_prep_s
         time_tot += time.time() - t_tot_s
     ap, auc = eval('val')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:

Now we compute updated node memory of all root and supporting nodes, but we only update the node memory with the computed root node memory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
